### PR TITLE
fix broken urls

### DIFF
--- a/index.html
+++ b/index.html
@@ -140,7 +140,7 @@ modern <a class="reference external" href="http://pyopengl.sourceforge.net">Open
 
            <h1>Spiral galaxy simulation</h1>
            <p> Simulation of a spiral galaxy using the density wave theory.</p>
-           <p><a class="btn btn-primary" href="#" role="button">See on github</a></p>
+           <p><a class="btn btn-primary" href="https://github.com/glumpy/glumpy" role="button">See on github</a></p>
          </div>
        </div>
      </div>
@@ -151,7 +151,7 @@ modern <a class="reference external" href="http://pyopengl.sourceforge.net">Open
          <div class="carousel-caption">
            <h1>Surface heightfield</h1>
            <p>10x10 numpy array represented as a GPU-computed heightfield.</p>
-           <p><a class="btn btn-primary" href="#" role="button">Learn more</a></p>
+           <p><a class="btn btn-primary" href="https://glumpy.readthedocs.io/en/latest/" role="button">Learn more</a></p>
          </div>
        </div>
      </div>
@@ -162,7 +162,7 @@ modern <a class="reference external" href="http://pyopengl.sourceforge.net">Open
          <div class="carousel-caption">
            <h1>High frequency signals</h1>
            <p>GPU multisampled high-frequency signal</p>
-           <p><a class="btn btn-primary" href="#" role="button">Browse gallery</a></p>
+           <p><a class="btn btn-primary" href="http://glumpy.github.io/gallery.html" role="button">Browse gallery</a></p>
          </div>
        </div>
      </div>
@@ -173,7 +173,7 @@ modern <a class="reference external" href="http://pyopengl.sourceforge.net">Open
          <div class="carousel-caption">
            <h1>Mandelbrot set</h1>
            <p>GPU computed fractals</p>
-           <p><a class="btn btn-primary" href="#" role="button">Show me more</a></p>
+           <p><a class="btn btn-primary" href="http://glumpy.github.io/gallery.html" role="button">Show me more</a></p>
          </div>
        </div>
      </div>
@@ -184,7 +184,7 @@ modern <a class="reference external" href="http://pyopengl.sourceforge.net">Open
          <div class="carousel-caption">
            <h1>Realtime signals</h1>
            <p>320 signals with 10 000 points each</p>
-           <p><a class="btn btn-primary" href="#" role="button">Waouh !</a></p>
+           <p><a class="btn btn-primary" href="http://glumpy.github.io/gallery.html" role="button">Waouh !</a></p>
          </div>
        </div>
      </div>
@@ -195,7 +195,7 @@ modern <a class="reference external" href="http://pyopengl.sourceforge.net">Open
          <div class="carousel-caption">
            <h1>SVG Rendering</h1>
            <p>Tiger display using collections and 2 GL calls</p>
-           <p><a class="btn btn-primary" href="#" role="button">I can't believe it</a></p>
+           <p><a class="btn btn-primary" href="http://glumpy.github.io/gallery.html" role="button">I can't believe it</a></p>
          </div>
        </div>
      </div>


### PR DESCRIPTION
I redirected `Waouh!`, `I can't believe it` and `Show me more` to http://glumpy.github.io/gallery.html because I didn't get its intention.
but I think it's better than redirecting to nothing.